### PR TITLE
Added ServiceStack OrmLite v4 to the benchmark tests

### DIFF
--- a/RawBencher/RawBencher.csproj
+++ b/RawBencher/RawBencher.csproj
@@ -53,8 +53,26 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\ReferencedAssemblies\LLBLGen41\SD.LLBLGen.Pro.ORMSupportClasses.dll</HintPath>
     </Reference>
+    <Reference Include="ServiceStack.Common">
+      <HintPath>..\packages\ServiceStack.Common.4.0.3\lib\net40\ServiceStack.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>..\packages\ServiceStack.Interfaces.4.0.3\lib\net40\ServiceStack.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.OrmLite">
+      <HintPath>..\packages\ServiceStack.OrmLite.4.0.3\lib\net40\ServiceStack.OrmLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.OrmLite.SqlServer">
+      <HintPath>..\packages\ServiceStack.OrmLite.SqlServer.4.0.3\lib\net40\ServiceStack.OrmLite.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\packages\ServiceStack.Text.4.0.3\lib\net40\ServiceStack.Text.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Xml.Linq" />

--- a/RawBencher/SalesOrderHeader.cs
+++ b/RawBencher/SalesOrderHeader.cs
@@ -7,202 +7,204 @@ using System.Collections.Generic;
 
 namespace RawBencher
 {
-	/// <summary>Class which represents the entity 'Sales.SalesOrderHeader'</summary>
-	public partial class SalesOrderHeader
-	{
-		#region Class Member Declarations
-		private System.String _accountNumber;
-		private System.String _comment;
-		private System.String _creditCardApprovalCode;
-		private System.DateTime _dueDate;
-		private System.Decimal _freight;
-		private System.DateTime _modifiedDate;
-		private System.Boolean _onlineOrderFlag;
-		private System.DateTime _orderDate;
-		private System.String _purchaseOrderNumber;
-		private System.Byte _revisionNumber;
-		private System.Guid _rowguid;
-		private System.Int32 _salesOrderId;
-		private System.String _salesOrderNumber;
-		private Nullable<System.DateTime> _shipDate;
-		private System.Byte _status;
-		private System.Decimal _subTotal;
-		private System.Decimal _taxAmt;
-		private System.Decimal _totalDue;
-		#endregion
+    /// <summary>Class which represents the entity 'Sales.SalesOrderHeader'</summary>
+    [ServiceStack.DataAnnotations.Schema("Sales")]
+    [ServiceStack.DataAnnotations.Alias("SalesOrderHeader")]
+    public partial class SalesOrderHeader
+    {
+        #region Class Member Declarations
+        private System.String _accountNumber;
+        private System.String _comment;
+        private System.String _creditCardApprovalCode;
+        private System.DateTime _dueDate;
+        private System.Decimal _freight;
+        private System.DateTime _modifiedDate;
+        private System.Boolean _onlineOrderFlag;
+        private System.DateTime _orderDate;
+        private System.String _purchaseOrderNumber;
+        private System.Byte _revisionNumber;
+        private System.Guid _rowguid;
+        private System.Int32 _salesOrderId;
+        private System.String _salesOrderNumber;
+        private Nullable<System.DateTime> _shipDate;
+        private System.Byte _status;
+        private System.Decimal _subTotal;
+        private System.Decimal _taxAmt;
+        private System.Decimal _totalDue;
+        #endregion
 
-		/// <summary>Initializes a new instance of the <see cref="SalesOrderHeader"/> class.</summary>
-		public SalesOrderHeader() : base()
-		{
-			_salesOrderId = default(System.Int32);
-			_salesOrderNumber = default(System.String);
-			_totalDue = default(System.Decimal);
-			OnCreated();
-		}
+        /// <summary>Initializes a new instance of the <see cref="SalesOrderHeader"/> class.</summary>
+        public SalesOrderHeader() : base()
+        {
+            _salesOrderId = default(System.Int32);
+            _salesOrderNumber = default(System.String);
+            _totalDue = default(System.Decimal);
+            OnCreated();
+        }
 
-		/// <summary>Method called from the constructor</summary>
-		partial void OnCreated();
+        /// <summary>Method called from the constructor</summary>
+        partial void OnCreated();
 
-		/// <summary>Returns a hash code for this instance.</summary>
-		/// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. </returns>
-		public override int GetHashCode()
-		{
-			int toReturn = base.GetHashCode();
-			toReturn ^= this.SalesOrderId.GetHashCode();
-			return toReturn;
-		}
-	
-		/// <summary>Determines whether the specified object is equal to this instance.</summary>
-		/// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
-		/// <returns><c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.</returns>
-		public override bool Equals(object obj)
-		{
-			if(obj == null) 
-			{
-				return false;
-			}
-			SalesOrderHeader toCompareWith = obj as SalesOrderHeader;
-			return toCompareWith == null ? false : ((this.SalesOrderId == toCompareWith.SalesOrderId));
-		}
-		
+        /// <summary>Returns a hash code for this instance.</summary>
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. </returns>
+        public override int GetHashCode()
+        {
+            int toReturn = base.GetHashCode();
+            toReturn ^= this.SalesOrderId.GetHashCode();
+            return toReturn;
+        }
+    
+        /// <summary>Determines whether the specified object is equal to this instance.</summary>
+        /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
+        /// <returns><c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.</returns>
+        public override bool Equals(object obj)
+        {
+            if(obj == null) 
+            {
+                return false;
+            }
+            SalesOrderHeader toCompareWith = obj as SalesOrderHeader;
+            return toCompareWith == null ? false : ((this.SalesOrderId == toCompareWith.SalesOrderId));
+        }
+        
 
-		#region Class Property Declarations
-		/// <summary>Gets or sets the AccountNumber field. </summary>	
-		public virtual System.String AccountNumber
-		{ 
-			get { return _accountNumber; }
-			set { _accountNumber = value; }
-		}
+        #region Class Property Declarations
+        /// <summary>Gets or sets the AccountNumber field. </summary>	
+        public virtual System.String AccountNumber
+        { 
+            get { return _accountNumber; }
+            set { _accountNumber = value; }
+        }
 
-		/// <summary>Gets or sets the Comment field. </summary>	
-		public virtual System.String Comment
-		{ 
-			get { return _comment; }
-			set { _comment = value; }
-		}
+        /// <summary>Gets or sets the Comment field. </summary>	
+        public virtual System.String Comment
+        { 
+            get { return _comment; }
+            set { _comment = value; }
+        }
 
-		/// <summary>Gets or sets the CreditCardApprovalCode field. </summary>	
-		public virtual System.String CreditCardApprovalCode
-		{ 
-			get { return _creditCardApprovalCode; }
-			set { _creditCardApprovalCode = value; }
-		}
+        /// <summary>Gets or sets the CreditCardApprovalCode field. </summary>	
+        public virtual System.String CreditCardApprovalCode
+        { 
+            get { return _creditCardApprovalCode; }
+            set { _creditCardApprovalCode = value; }
+        }
 
-		/// <summary>Gets or sets the DueDate field. </summary>	
-		public virtual System.DateTime DueDate
-		{ 
-			get { return _dueDate; }
-			set { _dueDate = value; }
-		}
+        /// <summary>Gets or sets the DueDate field. </summary>	
+        public virtual System.DateTime DueDate
+        { 
+            get { return _dueDate; }
+            set { _dueDate = value; }
+        }
 
-		/// <summary>Gets or sets the Freight field. </summary>	
-		public virtual System.Decimal Freight
-		{ 
-			get { return _freight; }
-			set { _freight = value; }
-		}
+        /// <summary>Gets or sets the Freight field. </summary>	
+        public virtual System.Decimal Freight
+        { 
+            get { return _freight; }
+            set { _freight = value; }
+        }
 
-		/// <summary>Gets or sets the ModifiedDate field. </summary>	
-		public virtual System.DateTime ModifiedDate
-		{ 
-			get { return _modifiedDate; }
-			set { _modifiedDate = value; }
-		}
+        /// <summary>Gets or sets the ModifiedDate field. </summary>	
+        public virtual System.DateTime ModifiedDate
+        { 
+            get { return _modifiedDate; }
+            set { _modifiedDate = value; }
+        }
 
-		/// <summary>Gets or sets the OnlineOrderFlag field. </summary>	
-		public virtual System.Boolean OnlineOrderFlag
-		{ 
-			get { return _onlineOrderFlag; }
-			set { _onlineOrderFlag = value; }
-		}
+        /// <summary>Gets or sets the OnlineOrderFlag field. </summary>	
+        public virtual System.Boolean OnlineOrderFlag
+        { 
+            get { return _onlineOrderFlag; }
+            set { _onlineOrderFlag = value; }
+        }
 
-		/// <summary>Gets or sets the OrderDate field. </summary>	
-		public virtual System.DateTime OrderDate
-		{ 
-			get { return _orderDate; }
-			set { _orderDate = value; }
-		}
+        /// <summary>Gets or sets the OrderDate field. </summary>	
+        public virtual System.DateTime OrderDate
+        { 
+            get { return _orderDate; }
+            set { _orderDate = value; }
+        }
 
-		/// <summary>Gets or sets the PurchaseOrderNumber field. </summary>	
-		public virtual System.String PurchaseOrderNumber
-		{ 
-			get { return _purchaseOrderNumber; }
-			set { _purchaseOrderNumber = value; }
-		}
+        /// <summary>Gets or sets the PurchaseOrderNumber field. </summary>	
+        public virtual System.String PurchaseOrderNumber
+        { 
+            get { return _purchaseOrderNumber; }
+            set { _purchaseOrderNumber = value; }
+        }
 
-		/// <summary>Gets or sets the RevisionNumber field. </summary>	
-		public virtual System.Byte RevisionNumber
-		{ 
-			get { return _revisionNumber; }
-			set { _revisionNumber = value; }
-		}
+        /// <summary>Gets or sets the RevisionNumber field. </summary>	
+        public virtual System.Byte RevisionNumber
+        { 
+            get { return _revisionNumber; }
+            set { _revisionNumber = value; }
+        }
 
-		/// <summary>Gets or sets the Rowguid field. </summary>	
-		public virtual System.Guid Rowguid
-		{ 
-			get { return _rowguid; }
-			set { _rowguid = value; }
-		}
+        /// <summary>Gets or sets the Rowguid field. </summary>	
+        public virtual System.Guid Rowguid
+        { 
+            get { return _rowguid; }
+            set { _rowguid = value; }
+        }
 
-		/// <summary>Gets the SalesOrderId field. </summary>	
-		public virtual System.Int32 SalesOrderId
-		{ 
-			get { return _salesOrderId; }
-			set { _salesOrderId = value; }
-		}
+        /// <summary>Gets the SalesOrderId field. </summary>	
+        public virtual System.Int32 SalesOrderId
+        { 
+            get { return _salesOrderId; }
+            set { _salesOrderId = value; }
+        }
 
-		/// <summary>Gets the SalesOrderNumber field. </summary>	
-		public virtual System.String SalesOrderNumber
-		{ 
-			get { return _salesOrderNumber; }
-			set { _salesOrderNumber = value; }
-		}
+        /// <summary>Gets the SalesOrderNumber field. </summary>	
+        public virtual System.String SalesOrderNumber
+        { 
+            get { return _salesOrderNumber; }
+            set { _salesOrderNumber = value; }
+        }
 
-		/// <summary>Gets or sets the ShipDate field. </summary>	
-		public virtual Nullable<System.DateTime> ShipDate
-		{ 
-			get { return _shipDate; }
-			set { _shipDate = value; }
-		}
+        /// <summary>Gets or sets the ShipDate field. </summary>	
+        public virtual Nullable<System.DateTime> ShipDate
+        { 
+            get { return _shipDate; }
+            set { _shipDate = value; }
+        }
 
-		/// <summary>Gets or sets the Status field. </summary>	
-		public virtual System.Byte Status
-		{ 
-			get { return _status; }
-			set { _status = value; }
-		}
+        /// <summary>Gets or sets the Status field. </summary>	
+        public virtual System.Byte Status
+        { 
+            get { return _status; }
+            set { _status = value; }
+        }
 
-		/// <summary>Gets or sets the SubTotal field. </summary>	
-		public virtual System.Decimal SubTotal
-		{ 
-			get { return _subTotal; }
-			set { _subTotal = value; }
-		}
+        /// <summary>Gets or sets the SubTotal field. </summary>	
+        public virtual System.Decimal SubTotal
+        { 
+            get { return _subTotal; }
+            set { _subTotal = value; }
+        }
 
-		/// <summary>Gets or sets the TaxAmt field. </summary>	
-		public virtual System.Decimal TaxAmt
-		{ 
-			get { return _taxAmt; }
-			set { _taxAmt = value; }
-		}
+        /// <summary>Gets or sets the TaxAmt field. </summary>	
+        public virtual System.Decimal TaxAmt
+        { 
+            get { return _taxAmt; }
+            set { _taxAmt = value; }
+        }
 
-		/// <summary>Gets the TotalDue field. </summary>	
-		public virtual System.Decimal TotalDue
-		{ 
-			get { return _totalDue; }
-			set { _totalDue = value; }
-		}
+        /// <summary>Gets the TotalDue field. </summary>	
+        public virtual System.Decimal TotalDue
+        { 
+            get { return _totalDue; }
+            set { _totalDue = value; }
+        }
 
-		public int CustomerID { get; set; }
-		public int ContactID { get; set; }
-		public int? SalesPersonID { get; set; }
-		public int? TerritoryID { get; set; }
-		public int BillToAddressID { get; set; }
-		public int ShipToAddressID { get; set; }
-		public int ShipMethodID { get; set; }
-		public int? CreditCardID { get; set; }
-		public int? CurrencyRateID { get; set; }
+        public int CustomerID { get; set; }
+        public int ContactID { get; set; }
+        public int? SalesPersonID { get; set; }
+        public int? TerritoryID { get; set; }
+        public int BillToAddressID { get; set; }
+        public int ShipToAddressID { get; set; }
+        public int ShipMethodID { get; set; }
+        public int? CreditCardID { get; set; }
+        public int? CurrencyRateID { get; set; }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/RawBencher/packages.config
+++ b/RawBencher/packages.config
@@ -3,4 +3,9 @@
   <package id="EntityFramework" version="6.0.1" targetFramework="net45" />
   <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net45" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net45" />
+  <package id="ServiceStack.Common" version="4.0.3" targetFramework="net451" />
+  <package id="ServiceStack.Interfaces" version="4.0.3" targetFramework="net451" />
+  <package id="ServiceStack.OrmLite" version="4.0.3" targetFramework="net451" />
+  <package id="ServiceStack.OrmLite.SqlServer" version="4.0.3" targetFramework="net451" />
+  <package id="ServiceStack.Text" version="4.0.3" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
I added ServiceStack OrmLite v4 to the tests. For me, on my local machine, the results for ServiceStack OrmLite were right in between Dapper and LLBLGen (without caching), which is exactly what I would have expected.

I also refactored a couple things, to make it work on my machine, might help the community if they try to run it. By allowing the program to run completely off connection strings in the app.config. I also changed the select \* from, to an explicit select [field1], [field2] from statement, as for some reason I didn't have the ContactID column in my table and I had to add it and re-ordering columns in a table is a pain (feel free to roll it back if that's not desired). Maybe I have a weird setup.

Otherwise, the code for servicestack is straight forward, I also added the servicestack binaries via nuget.
