### PR TITLE
A better assessment of Oak.DynamicDb

### DIFF
--- a/OakDynamicDb.Bencher/SalesOrderHeaders.cs
+++ b/OakDynamicDb.Bencher/SalesOrderHeaders.cs
@@ -15,6 +15,12 @@ namespace OakDynamicDb.Bencher
         public SalesOrderHeader() : base() { }
     }
 
+    public class SalesOrderHeaderDto : Gemini 
+    {
+        public SalesOrderHeaderDto(object dto) : base(dto) { }
+        public SalesOrderHeaderDto() : base() { }
+    }
+
     public class SalesOrderHeaders : DynamicRepository
     {
         public SalesOrderHeaders() : base("Sales.SalesOrderHeader", "SalesOrderID") 

--- a/RawBencher/Program.cs
+++ b/RawBencher/Program.cs
@@ -100,6 +100,10 @@ namespace RawBencher
             {
                 FetchSalesOrderHeaderOakDynamicDb();
             }
+            for (int i = 0; i < loopAmount; i++)
+            {
+                FetchSalesOrderHeaderOakDynamicDbDto();
+            }
 
 			Console.WriteLine("\nIndividual entity fetch benches");
 			Console.WriteLine("------------------------------------------");
@@ -488,13 +492,33 @@ namespace RawBencher
 
         private static void FetchSalesOrderHeaderOakDynamicDb()
         {
-            var frameworkName = "Oak.DynamicDb hydrating a dynamic type";
+            var frameworkName = "Oak.DyDynamicDb hydrating and binding a dynamic type, with change tracking";
             var sw = new Stopwatch();
             sw.Start();
             var db = new OakDynamicDb.Bencher.SalesOrderHeaders();
             var headers = db.All();
+            
+            foreach (var header in headers)
+            {
+                if (header.SalesOrderID <= 0)
+                {
+                    Console.WriteLine("Oak: Data is empty");
+                    break;
+                }
+            }
             sw.Stop();
+
             ReportResult(frameworkName, sw.ElapsedMilliseconds, headers.Count());
+        }
+
+        private static void FetchSalesOrderHeaderOakDynamicDbDto()
+        {
+            var frameworkName = "Oak.DyDynamicDb hydrating and binding a dynamic type, without change tracking";
+            var sw = new Stopwatch();
+            sw.Start();
+            var db = new OakDynamicDb.Bencher.SalesOrderHeaders();
+            db.Projection = d => new OakDynamicDb.Bencher.SalesOrderHeaderDto(d);
+            var headers = db.All();
 
             foreach (var header in headers)
             {
@@ -504,6 +528,9 @@ namespace RawBencher
                     break;
                 }
             }
+            sw.Stop();
+
+            ReportResult(frameworkName, sw.ElapsedMilliseconds, headers.Count());
         }
 
 		private static void GetVersionStrings(Assembly a, out string fileVersion, out string assemblyVersion)


### PR DESCRIPTION
For the `FetchSalesOrderHeaderOakDynamicDb` measurement, I moved the stop watch to _include_ the dynamic binding of Oak's DynamicModel. This is a much more accurate picture of the net time it takes to:
- retrieve the records
- attach methods associated with change tracking
- attach methods associated with validation
- attach methods associated with retrieving relationships

The numbers that you are seeing _is_ accurate. The lazy binding of the dynamic methods happens the first time a dynamic property is accessed, but as the benchmarks show, this process is slow.

I've added another method `FetchSalesOrderHeaderOakDynamicDbDto` that hydrates a dynamic object without change tracking. This option _is_ supported by the framework. And can be seen here: https://github.com/amirrajan/RawDataAccessBencher/compare/oak-dynamicdb?expand=1#diff-880238b8ae29809c5eb1471325d8f291R18
