### PR TITLE
LINQ to DB support

### DIFF
--- a/LINQ2DB/DAL/Db.cs
+++ b/LINQ2DB/DAL/Db.cs
@@ -1,0 +1,21 @@
+﻿using LinqToDB;
+using LinqToDB.DataProvider;
+using LinqToDB.DataProvider.SqlServer;
+
+namespace LINQ2DB.Bencher
+{
+    public class Db : LinqToDB.Data.DataConnection
+    {
+        public Db(string connetionString) : base(GetDataProvider(), connetionString)
+        {
+
+        }
+
+        private static IDataProvider GetDataProvider()
+        {
+            return new SqlServerDataProvider("", SqlServerVersion.v2008);
+        }
+
+        internal ITable<SalesOrderHeader> SalesOrderHeader { get { return GetTable<SalesOrderHeader>(); } }
+    }
+}

--- a/LINQ2DB/DAL/LINQ2DB.Bencher.csproj
+++ b/LINQ2DB/DAL/LINQ2DB.Bencher.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{06C162E5-0476-40F4-A705-8B5C265BFB68}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LINQ2DB.Bencher</RootNamespace>
+    <AssemblyName>LINQ2DB.Bencher</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="linq2db, Version=1.0.7.3, Culture=neutral, PublicKeyToken=f19f8aed7feff67e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\linq2db.1.0.7.3\lib\net45\linq2db.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Db.cs" />
+    <Compile Include="SalesOrderHeader.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SalesOrderHeaderRepository.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/LINQ2DB/DAL/Properties/AssemblyInfo.cs
+++ b/LINQ2DB/DAL/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LINQ2DB.Bencher")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LINQ2DB.Bencher")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("06c162e5-0476-40f4-a705-8b5c265bfb68")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LINQ2DB/DAL/SalesOrderHeader.cs
+++ b/LINQ2DB/DAL/SalesOrderHeader.cs
@@ -1,0 +1,87 @@
+﻿using LinqToDB.Mapping;
+using System;
+
+namespace LINQ2DB.Bencher
+{
+    [Table(Schema = "Sales", Name = "SalesOrderHeader")]
+    public class SalesOrderHeader
+    {
+        [Column]
+        public string AccountNumber { get; set; }
+
+        [Column]
+        public string Comment { get; set; }
+
+        [Column]
+        public string CreditCardApprovalCode { get; set; }
+
+        [Column]
+        public DateTime DueDate { get; set; }
+
+        [Column]
+        public decimal Freight { get; set; }
+
+        [Column]
+        public DateTime ModifiedDate { get; set; }
+
+        [Column]
+        public bool OnlineOrderFlag { get; set; }
+
+        [Column]
+        public DateTime OrderDate { get; set; }
+
+        [Column]
+        public string PurchaseOrderNumber { get; set; }
+
+        [Column]
+        public byte RevisionNumber { get; set; }
+
+        [Column]
+        public Guid Rowguid { get; set; }
+
+        [Column]
+        public int SalesOrderId { get; set; }
+
+        [Column]
+        public string SalesOrderNumber { get; set; }
+
+        [Column]
+        public DateTime? ShipDate { get; set; }
+
+        [Column]
+        public byte Status { get; set; }
+
+        [Column]
+        public decimal SubTotal { get; set; }
+
+        [Column]
+        public decimal TaxAmt { get; set; }
+
+        [Column]
+        public decimal TotalDue { get; set; }
+
+        [Column]
+        public int CustomerID { get; set; }
+
+        [Column]
+        public int? SalesPersonID { get; set; }
+
+        [Column]
+        public int? TerritoryID { get; set; }
+
+        [Column]
+        public int BillToAddressID { get; set; }
+
+        [Column]
+        public int ShipToAddressID { get; set; }
+
+        [Column]
+        public int ShipMethodID { get; set; }
+
+        [Column]
+        public int? CreditCardID { get; set; }
+
+        [Column]
+        public int? CurrencyRateID { get; set; }
+    }
+}

--- a/LINQ2DB/DAL/SalesOrderHeaderRepository.cs
+++ b/LINQ2DB/DAL/SalesOrderHeaderRepository.cs
@@ -1,0 +1,63 @@
+﻿using LinqToDB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LINQ2DB.Bencher
+{
+    public class SalesOrderHeaderRepository
+    {
+        public SalesOrderHeaderRepository(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }        
+        
+        public SalesOrderHeader Get(int id)
+        {
+            using (var db = new Db(ConnectionString))
+            {
+                return db.SalesOrderHeader
+                         .Where(p => p.SalesOrderId == id)
+                         .FirstOrDefault();                
+            }
+        }
+
+        static Func<Db, int, SalesOrderHeader> compiledGet = CompiledQuery.Compile((Db db, int id) =>
+        (
+            from soh in db.SalesOrderHeader
+            where soh.SalesOrderId == id
+            select soh
+        ).FirstOrDefault());
+
+        public SalesOrderHeader GetCompiled(int id)
+        {
+            using (var db = new Db(ConnectionString))
+            {                
+                return compiledGet(db, id);                
+            }
+        }
+
+        public IEnumerable<SalesOrderHeader> All()
+        {
+            using (var db = new Db(ConnectionString))
+            {
+                return db.SalesOrderHeader.ToList();
+            }
+        }
+
+        static Func<Db, IEnumerable<SalesOrderHeader>> compiledAll = CompiledQuery.Compile((Db db) =>        
+            from soh in db.SalesOrderHeader
+            select soh
+        );
+
+        public IEnumerable<SalesOrderHeader> AllCompiled()
+        {
+            using (var db = new Db(ConnectionString))
+            {
+                return compiledAll(db).ToList();
+            }
+        }        
+
+        public string ConnectionString { get; set; }
+    }
+}

--- a/LINQ2DB/DAL/packages.config
+++ b/LINQ2DB/DAL/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="linq2db" version="1.0.7.3" targetFramework="net46" />
+</packages>

--- a/RawBencher.DNX/project.json
+++ b/RawBencher.DNX/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "description": "RawBencher",
   "authors": [ "" ],

--- a/RawBencher.sln
+++ b/RawBencher.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24606.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RawBencher", "RawBencher\RawBencher.csproj", "{A4AA317A-6958-4D0C-B2EE-026005FD2C2E}"
 EndProject
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		RawBencher.DNX\global.json = RawBencher.DNX\global.json
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LINQ2DB.Bencher", "LINQ2DB\DAL\LINQ2DB.Bencher.csproj", "{06C162E5-0476-40F4-A705-8B5C265BFB68}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -133,13 +135,23 @@ Global
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Release|.NET.ActiveCfg = Release|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Release|.NET.Build.0 = Release|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{C5FD24A4-9E79-426D-BD58-754CF2403CD5}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Debug|.NET.ActiveCfg = Debug|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Debug|.NET.Build.0 = Debug|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Release|.NET.ActiveCfg = Release|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Release|.NET.Build.0 = Release|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{06C162E5-0476-40F4-A705-8B5C265BFB68}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RawBencher/Benchers/BencherBase.cs
+++ b/RawBencher/Benchers/BencherBase.cs
@@ -117,14 +117,15 @@ namespace RawBencher.Benchers
 		}
 
 
-		/// <summary>
-		/// Performs the individual bench mark. This is a benchmark which fetches all SalesOrderHeader elements with the keys specified, individually.
-		/// </summary>
-		/// <param name="keys">The keys for all elements to fetch.</param>
-		/// <returns>
-		/// A filled in benchmark result object, with the total time taken to fetch all elements of the keys specified. EnumerationTime is not set. Number of
-		/// </returns>
-		public BenchResult PerformIndividualBenchMark(List<int> keys)
+        /// <summary>
+        /// Performs the individual bench mark. This is a benchmark which fetches all SalesOrderHeader elements with the keys specified, individually.
+        /// </summary>
+        /// <param name="keys">The keys for all elements to fetch.</param>
+        /// <param name="discardResults">if set to <c>true</c> the results are returned but are not collected.</param>
+        /// <returns>
+        /// A filled in benchmark result object, with the total time taken to fetch all elements of the keys specified. EnumerationTime is not set. Number of
+        /// </returns>
+        public BenchResult PerformIndividualBenchMark(List<int> keys, bool discardResults)
 		{
 			var toReturn = new BenchResult();
 			int numberOfElementsFetched = 0;
@@ -142,18 +143,33 @@ namespace RawBencher.Benchers
 			sw.Stop();
 			toReturn.FetchTimeInMilliseconds = sw.ElapsedMilliseconds;
 			toReturn.NumberOfRowsFetched = numberOfElementsFetched;
-			_individualBenchmarkResults.Add(toReturn);
-
+            if (!discardResults)
+            {
+                _individualBenchmarkResults.Add(toReturn);
+            }
 			return toReturn;
 		}
 
-	
-		/// <summary>
-		/// Performs the set benchmark. This is a benchmark which fetches the full set of sales order headers, enumerates it and returns the times it took
-		/// to perform these actions as well as the number of rows read.
+
+        /// <summary>
+		/// Performs the individual bench mark. This is a benchmark which fetches all SalesOrderHeader elements with the keys specified, individually.
 		/// </summary>
-		/// <returns>A filled in benchmark result object</returns>
-		public BenchResult PerformSetBenchmark()
+		/// <param name="keys">The keys for all elements to fetch.</param>
+		/// <returns>
+		/// A filled in benchmark result object, with the total time taken to fetch all elements of the keys specified. EnumerationTime is not set. Number of
+		/// </returns>
+        public BenchResult PerformIndividualBenchMark(List<int> keys)
+        {
+            return PerformIndividualBenchMark(keys, discardResults: false);
+        }
+
+
+        /// <summary>
+        /// Performs the set benchmark. This is a benchmark which fetches the full set of sales order headers, enumerates it and returns the times it took
+        /// to perform these actions as well as the number of rows read.
+        /// </summary>
+        /// <returns>A filled in benchmark result object</returns>
+        public BenchResult PerformSetBenchmark()
 		{
 			return PerformSetBenchmark(discardResults: false);
 		}

--- a/RawBencher/Benchers/IBencher.cs
+++ b/RawBencher/Benchers/IBencher.cs
@@ -25,12 +25,21 @@ namespace RawBencher.Benchers
 		/// A filled in benchmark result object, with the total time taken to fetch all elements of the keys specified. EnumerationTime is not set. Number of
 		/// </returns>
 		BenchResult PerformIndividualBenchMark(List<int> keys);
-		/// <summary>
-		/// Performs the set benchmark. This is a benchmark which fetches the full set of sales order headers, enumerates it and returns the times it took
-		/// to perform these actions as well as the number of rows read.
+        /// <summary>
+		/// Performs the individual bench mark. This is a benchmark which fetches all SalesOrderHeader elements with the keys specified, individually.
 		/// </summary>
-		/// <returns>A filled in benchmark result object</returns>
-		BenchResult PerformSetBenchmark();
+		/// <param name="keys">The keys for all elements to fetch.</param>
+        /// <param name="discardResults">if set to <c>true</c> the results are returned but are not collected.</param>
+		/// <returns>
+		/// A filled in benchmark result object, with the total time taken to fetch all elements of the keys specified. EnumerationTime is not set. Number of
+		/// </returns>
+		BenchResult PerformIndividualBenchMark(List<int> keys, bool discardResults);
+        /// <summary>
+        /// Performs the set benchmark. This is a benchmark which fetches the full set of sales order headers, enumerates it and returns the times it took
+        /// to perform these actions as well as the number of rows read.
+        /// </summary>
+        /// <returns>A filled in benchmark result object</returns>
+        BenchResult PerformSetBenchmark();
 		/// <summary>
 		/// Performs the set benchmark. This is a benchmark which fetches the full set of sales order headers, enumerates it and returns the times it took
 		/// to perform these actions as well as the number of rows read.

--- a/RawBencher/Benchers/LINQ2DBCompiledBencher.cs
+++ b/RawBencher/Benchers/LINQ2DBCompiledBencher.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RawBencher.Benchers
+{
+    public class LINQ2DBCompiledBencher : BencherBase<LINQ2DB.Bencher.SalesOrderHeader>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LINQ2DBCompiledBencher"/> class.
+        /// </summary>
+        public LINQ2DBCompiledBencher(string connectionString)
+			: base(e => e.SalesOrderId, usesChangeTracking:false, usesCaching:false)
+		{
+            Repository = new LINQ2DB.Bencher.SalesOrderHeaderRepository(connectionString);
+        }
+
+        /// <summary>
+		/// Fetches the individual element
+		/// </summary>
+		/// <param name="key">The key of the element to fetch.</param>
+		/// <returns>The fetched element, or null if not found</returns>
+        public override LINQ2DB.Bencher.SalesOrderHeader FetchIndividual(int key)
+        {
+            return Repository.GetCompiled(key);
+        }
+
+        /// <summary>
+		/// Fetches the complete set of elements and returns this set as an IEnumerable. It
+        /// uses a compiled query to return the results.
+		/// </summary>
+		/// <returns>the set fetched</returns>
+        public override IEnumerable<LINQ2DB.Bencher.SalesOrderHeader> FetchSet()
+        {
+            return Repository.AllCompiled();
+        }
+
+        /// <summary>
+		/// Creates the name of the framework this bencher is for. 
+		/// </summary>
+		/// <returns>the framework name.</returns>
+        protected override string CreateFrameworkNameImpl()
+        {
+            return "LINQ to DB v1.0.7.3 (compiled)";
+        }
+
+        private LINQ2DB.Bencher.SalesOrderHeaderRepository Repository { get; set; }
+    }
+}

--- a/RawBencher/Benchers/LINQ2DBNormalBencher.cs
+++ b/RawBencher/Benchers/LINQ2DBNormalBencher.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RawBencher.Benchers
+{
+    public class LINQ2DBNormalBencher : BencherBase<LINQ2DB.Bencher.SalesOrderHeader>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LINQ2DBNormalBencher"/> class.
+        /// </summary>
+        public LINQ2DBNormalBencher(string connectionString)
+			: base(e => e.SalesOrderId, usesChangeTracking:false, usesCaching:false)
+		{
+            Repository = new LINQ2DB.Bencher.SalesOrderHeaderRepository(connectionString);
+        }
+
+        /// <summary>
+		/// Fetches the individual element
+		/// </summary>
+		/// <param name="key">The key of the element to fetch.</param>
+		/// <returns>The fetched element, or null if not found</returns>
+        public override LINQ2DB.Bencher.SalesOrderHeader FetchIndividual(int key)
+        {
+            return Repository.Get(key);
+        }
+
+        /// <summary>
+		/// Fetches the complete set of elements and returns this set as an IEnumerable.
+		/// </summary>
+		/// <returns>the set fetched</returns>
+        public override IEnumerable<LINQ2DB.Bencher.SalesOrderHeader> FetchSet()
+        {
+            return Repository.All();
+        }
+
+        /// <summary>
+		/// Creates the name of the framework this bencher is for. 
+		/// </summary>
+		/// <returns>the framework name.</returns>
+        protected override string CreateFrameworkNameImpl()
+        {
+            return "LINQ to DB v1.0.7.3 (normal)";
+        }
+
+        private LINQ2DB.Bencher.SalesOrderHeaderRepository Repository { get; set; }
+    }
+}

--- a/RawBencher/Program.cs
+++ b/RawBencher/Program.cs
@@ -261,7 +261,7 @@ namespace RawBencher
 			bencher.ResetResults();
 			Console.WriteLine("First one warm-up run to initialize constructs. Results will not be collected.");
 			var result = bencher.PerformSetBenchmark(discardResults: true);
-            //bencher.PerformIndividualBenchMark(KeysForIndividualFetches, discardResults: true);
+            bencher.PerformIndividualBenchMark(KeysForIndividualFetches, discardResults: true);
 			ReportSetResult(bencher, result);
 			Console.WriteLine("Starting bench runs...");
 			if(PerformSetBenchmarks)

--- a/RawBencher/Program.cs
+++ b/RawBencher/Program.cs
@@ -62,32 +62,34 @@ namespace RawBencher
 			CacheController.RegisterCache(ConnectionString, new ResultsetCache());
 #endif
 
-			RegisteredBenchers.Add(new HandCodedBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
-			RegisteredBenchers.Add(new HandCodedBencherUsingBoxing() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
-			RegisteredBenchers.Add(new RawDbDataReaderBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
-			RegisteredBenchers.Add(new DapperBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new HandCodedBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new HandCodedBencherUsingBoxing() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new RawDbDataReaderBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new DapperBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new LINQ2DBNormalBencher(ConnectionString));
+            RegisteredBenchers.Add(new LINQ2DBCompiledBencher(ConnectionString));
 
 #if !DNXCORE50
-			RegisteredBenchers.Add(new MassiveBencher());
-			RegisteredBenchers.Add(new OrmLiteBencher() { ConnectionStringToUse = ConnectionString });
-			RegisteredBenchers.Add(new DataTableBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new MassiveBencher());
+            RegisteredBenchers.Add(new OrmLiteBencher() { ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new DataTableBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
 #endif
 
 #if !(DNXCORE50 || DNX451)
-			RegisteredBenchers.Add(new EntityFrameworkNoChangeTrackingBencher());
-			RegisteredBenchers.Add(new EntityFrameworkNormalBencher());
-			RegisteredBenchers.Add(new LinqToSqlNoChangeTrackingBencher());
-			RegisteredBenchers.Add(new LLBLGenProNoChangeTrackingLinqPocoBencher());
-			RegisteredBenchers.Add(new LLBLGenProNoChangeTrackingQuerySpecPocoBencher());
-			RegisteredBenchers.Add(new LLBLGenProNoChangeTrackingBencher());
-			RegisteredBenchers.Add(new LLBLGenProResultsetCachingBencher());
-			RegisteredBenchers.Add(new LLBLGenProNormalBencher());
-			RegisteredBenchers.Add(new LinqToSqlNormalBencher());
-			RegisteredBenchers.Add(new OakDynamicDbDtoBencher());
-			RegisteredBenchers.Add(new OakDynamicDbNormalBencher());
-			RegisteredBenchers.Add(new NHibernateNormalBencher());
-			RegisteredBenchers.Add(new PetaPocoBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
-			RegisteredBenchers.Add(new PetaPocoFastBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new EntityFrameworkNoChangeTrackingBencher());
+            RegisteredBenchers.Add(new EntityFrameworkNormalBencher());
+            RegisteredBenchers.Add(new LinqToSqlNoChangeTrackingBencher());
+            RegisteredBenchers.Add(new LLBLGenProNoChangeTrackingLinqPocoBencher());
+            RegisteredBenchers.Add(new LLBLGenProNoChangeTrackingQuerySpecPocoBencher());
+            RegisteredBenchers.Add(new LLBLGenProNoChangeTrackingBencher());
+            RegisteredBenchers.Add(new LLBLGenProResultsetCachingBencher());
+            RegisteredBenchers.Add(new LLBLGenProNormalBencher());
+            RegisteredBenchers.Add(new LinqToSqlNormalBencher());
+            RegisteredBenchers.Add(new OakDynamicDbDtoBencher());
+            RegisteredBenchers.Add(new OakDynamicDbNormalBencher());
+            RegisteredBenchers.Add(new NHibernateNormalBencher());
+            RegisteredBenchers.Add(new PetaPocoBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new PetaPocoFastBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
 #endif
 
 
@@ -97,7 +99,7 @@ namespace RawBencher
 
 
 
-			DisplayHeader();
+            DisplayHeader();
 	
 			WarmupDB();
 			FetchKeysForIndividualFetches();
@@ -259,6 +261,7 @@ namespace RawBencher
 			bencher.ResetResults();
 			Console.WriteLine("First one warm-up run to initialize constructs. Results will not be collected.");
 			var result = bencher.PerformSetBenchmark(discardResults: true);
+            //bencher.PerformIndividualBenchMark(KeysForIndividualFetches, discardResults: true);
 			ReportSetResult(bencher, result);
 			Console.WriteLine("Starting bench runs...");
 			if(PerformSetBenchmarks)

--- a/RawBencher/RawBencher.csproj
+++ b/RawBencher/RawBencher.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="linq2db, Version=1.0.7.3, Culture=neutral, PublicKeyToken=f19f8aed7feff67e, processorArchitecture=MSIL">
+      <HintPath>..\packages\linq2db.1.0.7.3\lib\net45\linq2db.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
       <Private>True</Private>
@@ -95,6 +99,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Benchers\BencherBase.cs" />
+    <Compile Include="Benchers\LINQ2DBCompiledBencher.cs" />
+    <Compile Include="Benchers\LINQ2DBNormalBencher.cs" />
     <Compile Include="Benchers\MassiveBencher.cs" />
     <Compile Include="Benchers\HandCodedBencherUsingBoxing.cs" />
     <Compile Include="Benchers\LLBLGenProNoChangeTrackingQuerySpecPocoBencher.cs" />
@@ -143,6 +149,10 @@
     <ProjectReference Include="..\L2S\DAL\L2S.Bencher.csproj">
       <Project>{59322c25-fcc6-4635-a7ad-dc811f2fd1e0}</Project>
       <Name>L2S.Bencher</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\LINQ2DB\DAL\LINQ2DB.Bencher.csproj">
+      <Project>{06c162e5-0476-40f4-a705-8b5c265bfb68}</Project>
+      <Name>LINQ2DB.Bencher</Name>
     </ProjectReference>
     <ProjectReference Include="..\LLBLGen42\AdventureWorks.Dal.Adapter.v42.csproj">
       <Project>{cede6074-9d0e-49e2-8600-532b89b19111}</Project>

--- a/RawBencher/packages.config
+++ b/RawBencher/packages.config
@@ -3,6 +3,7 @@
   <package id="Dapper" version="1.42" targetFramework="net451" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net451" />
+  <package id="linq2db" version="1.0.7.3" targetFramework="net451" />
   <package id="NHibernate" version="4.0.4.4000" targetFramework="net451" />
   <package id="SD.LLBLGen.Pro.ORMSupportClasses" version="4.2.20151023" targetFramework="net451" />
   <package id="ServiceStack.Common" version="4.0.46" targetFramework="net451" />


### PR DESCRIPTION
I've added support for LINQ to DB. Also, I've tweaked PerformIndividualBenchMark to allow running without keeping the results -- similar to how PerformSetBenchmark works. The reasoning for this is that if you want to measure materialization then the first access shouldn't matter. If you don't like this behavior, you can disable it from Program.cs (line 264).

Since LINQ to DB allows for query compilation, I made two "benchers" (normal and one that uses query compilation). On my laptop I got the following results (the database was on the same computer):

Results per framework. Values are given as: 'mean (standard deviation)'

Non-change tracking fetches, set fetches (25 runs), no caching

Handcoded materializer using DbDataReader                            : 155.52ms (3.83ms)        Enum: 0.00ms (0.00ms)
Handcoded materializer using DbDataReader (GetValues(array), boxing) : 165.00ms (1.33ms)        Enum: 1.00ms (0.00ms)
Raw DbDataReader materializer using object arrays                    : 175.68ms (4.30ms)        Enum: 2.00ms (0.00ms)
LINQ to DB v1.0.7.3 (normal)                                         : 176.68ms (1.71ms)        Enum: 0.84ms (0.37ms)
LINQ to DB v1.0.7.3 (compiled)                                       : 182.20ms (7.45ms)        Enum: 0.04ms (0.20ms)
PetaPoco Fast v1.0.0.0                                               : 193.36ms (8.79ms)        Enum: 0.84ms (0.37ms)
PetaPoco v1.0.0.0                                                    : 216.84ms (12.27ms)       Enum: 1.00ms (0.28ms)
Dapper v1.40.0.0                                                     : 221.84ms (3.64ms)        Enum: 0.96ms (0.20ms)
Linq to Sql v4.0.0.0 (v4.6.81.0)                                     : 246.68ms (8.27ms)        Enum: 1.00ms (0.00ms)
Entity Framework v6.0.0.0 (v6.1.40302.0)                             : 247.92ms (5.89ms)        Enum: 1.00ms (0.00ms)
LLBLGen Pro v4.2.0.0 (v4.2.15.1015), Poco typed view with QuerySpec  : 340.60ms (3.26ms)        Enum: 0.76ms (0.43ms)
LLBLGen Pro v4.2.0.0 (v4.2.15.1015), Poco typed view with Linq       : 384.48ms (2.47ms)        Enum: 0.16ms (0.37ms)
LLBLGen Pro v4.2.0.0 (v4.2.15.1015), typed view                      : 431.12ms (4.39ms)        Enum: 3.32ms (1.57ms)
ServiceStack OrmLite v4.0.46.0 (v4.0.46.0)                           : 486.72ms (4.22ms)        Enum: 0.28ms (0.45ms)
Massive using dynamic class                                          : 563.68ms (9.24ms)        Enum: 25.68ms (1.64ms)
Oak.DynamicDb using dynamic Dto class                                : 702.48ms (20.83ms)       Enum: 126.96ms (18.82ms)


Change tracking fetches, set fetches (25 runs), no caching

DataTable, using DbDataAdapter                                       : 270.92ms (4.12ms)        Enum: 30.52ms (0.64ms)
Linq to Sql v4.0.0.0 (v4.6.81.0)                                     : 343.72ms (4.57ms)        Enum: 1.00ms (0.00ms)
LLBLGen Pro v4.2.0.0 (v4.2.15.1015)                                  : 422.36ms (14.87ms)       Enum: 6.00ms (0.00ms)
Oak.DynamicDb using typed dynamic class                              : 699.12ms (18.47ms)       Enum: 807.52ms (29.04ms)

NHibernate v4.0.0.4000 (v4.0.4.4000)                                 : 2,944.48ms (33.51ms)     Enum: 1.04ms (0.20ms)
Entity Framework v6.0.0.0 (v6.1.40302.0)                             : 3,244.04ms (52.59ms)     Enum: 1.08ms (0.27ms)

Non-change tracking individual fetches (100 elements, 25 runs), no caching

Handcoded materializer using DbDataReader (GetValues(array), boxing) : 0.12ms (0.01ms) per individual fetch
Handcoded materializer using DbDataReader                            : 0.12ms (0.01ms) per individual fetch
Dapper v1.40.0.0                                                     : 0.14ms (0.01ms) per individual fetch
Raw DbDataReader materializer using object arrays                    : 0.20ms (0.01ms) per individual fetch
Massive using dynamic class                                          : 0.21ms (0.01ms) per individual fetch
Oak.DynamicDb using dynamic Dto class                                : 0.23ms (0.01ms) per individual fetch
ServiceStack OrmLite v4.0.46.0 (v4.0.46.0)                           : 0.24ms (0.02ms) per individual fetch
LINQ to DB v1.0.7.3 (compiled)                                       : 0.33ms (0.01ms) per individual fetch
LLBLGen Pro v4.2.0.0 (v4.2.15.1015), Poco typed view with QuerySpec  : 0.36ms (0.01ms) per individual fetch
PetaPoco Fast v1.0.0.0                                               : 0.36ms (0.02ms) per individual fetch
LINQ to DB v1.0.7.3 (normal)                                         : 0.38ms (0.01ms) per individual fetch
LLBLGen Pro v4.2.0.0 (v4.2.15.1015), typed view                      : 0.50ms (0.01ms) per individual fetch
Entity Framework v6.0.0.0 (v6.1.40302.0)                             : 0.61ms (0.01ms) per individual fetch
LLBLGen Pro v4.2.0.0 (v4.2.15.1015), Poco typed view with Linq       : 1.35ms (0.02ms) per individual fetch
Linq to Sql v4.0.0.0 (v4.6.81.0)                                     : 1.64ms (0.03ms) per individual fetch
PetaPoco v1.0.0.0                                                    : 4.16ms (0.10ms) per individual fetch

Change tracking individual fetches (100 elements, 25 runs), no caching

DataTable, using DbDataAdapter                                       : 0.22ms (0.01ms) per individual fetch
Oak.DynamicDb using typed dynamic class                              : 0.26ms (0.01ms) per individual fetch
LLBLGen Pro v4.2.0.0 (v4.2.15.1015)                                  : 0.31ms (0.01ms) per individual fetch
NHibernate v4.0.0.4000 (v4.0.4.4000)                                 : 0.45ms (0.01ms) per individual fetch
Entity Framework v6.0.0.0 (v6.1.40302.0)                             : 0.72ms (0.02ms) per individual fetch
Linq to Sql v4.0.0.0 (v4.6.81.0)                                     : 1.71ms (0.03ms) per individual fetch

Change tracking fetches, set fetches (25 runs), caching

LLBLGen Pro v4.2.0.0 (v4.2.15.1015)                                  : 137.48ms (7.00ms)        Enum: 4.48ms (0.70ms)

Change tracking individual fetches (100 elements, 25 runs), caching

LLBLGen Pro v4.2.0.0 (v4.2.15.1015)                                  : 0.16ms (0.00ms) per individual fetch