### PR TITLE
Update OrmLite Usage

### DIFF
--- a/RawBencher/Benchers/OrmLiteBencher.cs
+++ b/RawBencher/Benchers/OrmLiteBencher.cs
@@ -6,16 +6,17 @@ using ServiceStack.OrmLite;
 
 namespace RawBencher.Benchers
 {
-	/// <summary>
-	/// Specific bencher for OrmLite , doing no-change tracking fetch
-	/// </summary>
-	public class OrmLiteBencher : BencherBase<SalesOrderHeader>
-	{
+    /// <summary>
+    /// Specific bencher for OrmLite, doing no-change tracking fetch
+    /// </summary>
+    public class OrmLiteBencher : BencherBase<SalesOrderHeader>
+    {
         /// <summary>
         /// Initializes a new instance of the <see cref="OrmLiteBencher"/> class.
         /// </summary>
         public OrmLiteBencher()
-			: base(e => e.SalesOrderId, usesChangeTracking:false, usesCaching:false) {}
+            : base(e => e.SalesOrderId, usesChangeTracking: false, usesCaching: false)
+        { }
 
         /// <summary>
         /// Fetches the individual element
@@ -23,7 +24,7 @@ namespace RawBencher.Benchers
         /// <param name="key">The key of the element to fetch.</param>
         /// <returns>The fetched element, or null if not found</returns>
         public override SalesOrderHeader FetchIndividual(int key)
-		{
+        {
             SalesOrderHeader toReturn = null;
             using (var con = dbFactory.OpenDbConnection())
             {
@@ -33,33 +34,30 @@ namespace RawBencher.Benchers
             return toReturn;
         }
 
+        /// <summary>
+        /// Fetches the complete set of elements and returns this set as an IEnumerable.
+        /// </summary>
+        /// <returns>the set fetched</returns>
+        public override IEnumerable<SalesOrderHeader> FetchSet()
+        {
+            var headers = new List<SalesOrderHeader>();
+            using (var con = dbFactory.OpenDbConnection())
+            {
+                headers = con.SqlList<SalesOrderHeader>(this.CommandText);
+                con.Close();
+            }
+            return headers;
+        }
 
-		/// <summary>
-		/// Fetches the complete set of elements and returns this set as an IEnumerable.
-		/// </summary>
-		/// <returns>the set fetched</returns>
-		public override IEnumerable<SalesOrderHeader> FetchSet()
-		{
-			var headers = new List<SalesOrderHeader>();
-			using(var con = dbFactory.OpenDbConnection())
-			{
-				headers = con.SqlList<SalesOrderHeader>(this.CommandText);
-				con.Close();
-			}
-			return headers;
-		}
-
-
-		/// <summary>
-		/// Creates the name of the framework this bencher is for. Use the overload which accepts a format string and a type to create a name based on a
-		/// specific version
-		/// </summary>
-		/// <returns>the framework name.</returns>
-		protected override string CreateFrameworkNameImpl()
-		{
-			return CreateFrameworkName("ServiceStack OrmLite v{0} (v{1})", typeof(OrmLiteConnectionFactory));
-		}
-
+        /// <summary>
+        /// Creates the name of the framework this bencher is for. Use the overload which accepts a format string and a type to create a name based on a
+        /// specific version
+        /// </summary>
+        /// <returns>the framework name.</returns>
+        protected override string CreateFrameworkNameImpl()
+        {
+            return CreateFrameworkName("ServiceStack OrmLite v{0} (v{1})", typeof(OrmLiteConnectionFactory));
+        }
 
         #region Properties
         /// <summary>
@@ -68,7 +66,7 @@ namespace RawBencher.Benchers
         IDbConnectionFactory dbFactory;
         public string ConnectionStringToUse
         {
-		    set { dbFactory = new OrmLiteConnectionFactory(value, SqlServerDialect.Provider); }
+            set { dbFactory = new OrmLiteConnectionFactory(value, SqlServerDialect.Provider); }
         }
 
         public string CommandText { get; set; }

--- a/RawBencher/Program.cs
+++ b/RawBencher/Program.cs
@@ -68,7 +68,7 @@ namespace RawBencher
 #if !DNXCORE50
 			RegisteredBenchers.Add(new DataTableBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
 			RegisteredBenchers.Add(new MassiveBencher());
-			RegisteredBenchers.Add(new OrmLiteBencher() { ConnectionStringToUse = ConnectionString });
+            RegisteredBenchers.Add(new OrmLiteBencher() { CommandText = SqlSelectCommandText, ConnectionStringToUse = ConnectionString });
 #endif
 
 #if !(DNXCORE50 || DNX451)


### PR DESCRIPTION
Hi Frans,

Update OrmLite to match proper usage of `OrmLiteConnectionFactory` which should be a singleton instance that's should only be initialized once on Startup.

Changed the API used to match usage in Dapper by executing Custom SQL.

Sorry about spaces, just realized you're using tabs now (IMO they're unfriendly defaults for a collaborative repo). Feel free to copy code instead of merging PR.

BTW thx for creating this new benchmarks suite to profile OrmLite on and pointers for using GetValues() - now using them in latest v4.0.50 OrmLite release.