### PR TITLE
Fixing NHibernate eager fetching query. 

### DIFF
--- a/RawBencher/Benchers/NHibernateNormalBencher.cs
+++ b/RawBencher/Benchers/NHibernateNormalBencher.cs
@@ -59,13 +59,11 @@ namespace RawBencher.Benchers
 		{
 			using(var session = SessionManager.OpenSession())
 			{
-				// [FB] I have the feeling this isn't optimal, as it fetches the parent nodes with each child node. However no idea how to specify this better w/o string queries.
-				var q = (from soh in session.Query<NH.Bencher.EntityClasses.SalesOrderHeader>()
-						where soh.SalesOrderId > 50000 && soh.SalesOrderId <= 51000
-						select soh);
-				q.FetchMany(x=>x.SalesOrderDetails).ToFuture();
-				q.Fetch(x => x.Customer).ToFuture();
-				return q.ToFuture().ToList();
+				return session.Query<NH.Bencher.EntityClasses.SalesOrderHeader>()
+					.Where(soh => soh.SalesOrderId > 50000 && soh.SalesOrderId <= 51000)
+					.Fetch(x => x.Customer)
+					.Fetch(x => x.SalesOrderDetails)
+					.ToList();
 			}
 		}
 


### PR DESCRIPTION
I think the ToFuture() was messing up how NHibernate decided to create the queries; it resulted in a separate query for each entity instead of just a single query with a LEFT JOIN.

However, it does not seem to affected performance positively or negatively.