### PR TITLE
Added the RepoDb.SqlServer reference and the bootstrapper.

### DIFF
--- a/RawBencher.Core/RawBencher.Core.csproj
+++ b/RawBencher.Core/RawBencher.Core.csproj
@@ -62,8 +62,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
       <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
       <PackageReference Include="NPoco" Version="4.0.1" />
-      <PackageReference Include="RepoDb" Version="1.10.11" />
-      <PackageReference Include="RepoDb.SqlServer" Version="1.0.6" />
+      <PackageReference Include="RepoDb" Version="1.9.5" />
       <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.6.0" />
       <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.5.0" />
       <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
@@ -71,7 +70,7 @@
       <PackageReference Include="Tortuga.Chain.CompiledMaterializers" Version="2.1.7009.34082" />
       <PackageReference Include="Tortuga.Chain.Core" Version="2.1.7009.31212" />
       <PackageReference Include="Tortuga.Chain.SqlServer" Version="2.1.7009.33175" />
-      <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
+      <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
     </ItemGroup>
 
 </Project>

--- a/RawBencher.Core/RawBencher.Core.csproj
+++ b/RawBencher.Core/RawBencher.Core.csproj
@@ -62,7 +62,8 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
       <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
       <PackageReference Include="NPoco" Version="4.0.1" />
-      <PackageReference Include="RepoDb" Version="1.9.5" />
+      <PackageReference Include="RepoDb" Version="1.10.11" />
+      <PackageReference Include="RepoDb.SqlServer" Version="1.0.6" />
       <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.6.0" />
       <PackageReference Include="ServiceStack.OrmLite.SqlServer" Version="5.5.0" />
       <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
@@ -70,7 +71,7 @@
       <PackageReference Include="Tortuga.Chain.CompiledMaterializers" Version="2.1.7009.34082" />
       <PackageReference Include="Tortuga.Chain.Core" Version="2.1.7009.31212" />
       <PackageReference Include="Tortuga.Chain.SqlServer" Version="2.1.7009.33175" />
-      <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
+      <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
     </ItemGroup>
 
 </Project>

--- a/RawBencher/BenchController.cs
+++ b/RawBencher/BenchController.cs
@@ -97,6 +97,7 @@ namespace RawBencher
             BenchController.DisplayHeader();
 			BenchController.WarmupDB();
 			BenchController.FetchKeysForIndividualFetches();
+            BenchController.Bootstrap();
 
 			// Uncomment the line below if you want to profile a bencher. Specify the bencher instance and follow the guides on the screen.
 			//ProfileBenchers(RegisteredBenchers.FirstOrDefault(b => b.GetType() == typeof(LINQ2DBNormalBencher)));
@@ -248,6 +249,17 @@ namespace RawBencher
 			}
 		}
 
+		private static void Bootstrap()
+		{
+			// RepoDb
+			RepoDb.SqlServerBootstrap.Initialize();
+
+			// EF
+
+			// LLBLGen
+
+			// Others
+		}
 
 		private static void RunRegisteredBenchers()
 		{

--- a/RawBencher/BenchController.cs
+++ b/RawBencher/BenchController.cs
@@ -97,7 +97,6 @@ namespace RawBencher
             BenchController.DisplayHeader();
 			BenchController.WarmupDB();
 			BenchController.FetchKeysForIndividualFetches();
-            BenchController.Bootstrap();
 
 			// Uncomment the line below if you want to profile a bencher. Specify the bencher instance and follow the guides on the screen.
 			//ProfileBenchers(RegisteredBenchers.FirstOrDefault(b => b.GetType() == typeof(LINQ2DBNormalBencher)));
@@ -249,17 +248,6 @@ namespace RawBencher
 			}
 		}
 
-		private static void Bootstrap()
-		{
-			// RepoDb
-			RepoDb.SqlServerBootstrap.Initialize();
-
-			// EF
-
-			// LLBLGen
-
-			// Others
-		}
 
 		private static void RunRegisteredBenchers()
 		{

--- a/RawBencher/Benchers/BencherBase.cs
+++ b/RawBencher/Benchers/BencherBase.cs
@@ -78,6 +78,11 @@ namespace RawBencher.Benchers
 
 
 		/// <summary>
+		/// Initializes the current bencher instance.
+		/// </summary>
+		public virtual void Initialize() { }
+
+		/// <summary>
 		/// Resets the result containers of this bencher.
 		/// </summary>
 		public void ResetResults()

--- a/RawBencher/Benchers/IBencher.cs
+++ b/RawBencher/Benchers/IBencher.cs
@@ -96,7 +96,10 @@ namespace RawBencher.Benchers
 		/// A filled in benchmark result object
 		/// </returns>
 		BenchResult PerformInsertSetBenchmark(int amountToInsert, int batchSize, bool discardResults);
-
+		/// <summary>
+		/// Initializes the current bencher instance.
+		/// </summary>
+		void Initialize();
 		/// <summary>
 		/// Gets / sets the flag to collect memory allocations during an operation
 		/// </summary>

--- a/RawBencher/Benchers/RepoDbPocoBencher.cs
+++ b/RawBencher/Benchers/RepoDbPocoBencher.cs
@@ -17,6 +17,16 @@ namespace RawBencher.Benchers
         public RepoDbPocoBencher()
             : base(e => e.SalesOrderId, usesChangeTracking: false, usesCaching: false)
         {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Initializes the current bencher instance.
+        /// </summary>
+        public override void Initialize()
+        {
+            base.Initialize();
+            SqlServerBootstrap.Initialize();
         }
 
         /// <summary>

--- a/RawBencher/Benchers/RepoDbRawSqlBencher.cs
+++ b/RawBencher/Benchers/RepoDbRawSqlBencher.cs
@@ -17,6 +17,16 @@ namespace RawBencher.Benchers
         public RepoDbRawSqlBencher()
             : base(e => e.SalesOrderId, usesChangeTracking: false, usesCaching: false)
         {
+            Initialize();
+        }
+
+        /// <summary>
+		/// Initializes the current bencher instance.
+		/// </summary>
+        public override void Initialize()
+        {
+            base.Initialize();
+            SqlServerBootstrap.Initialize();
         }
 
         /// <summary>

--- a/RawBencher/RawBencher.csproj
+++ b/RawBencher/RawBencher.csproj
@@ -85,9 +85,6 @@
       <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.3.1.0\lib\netstandard2.0\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.SqlClient, Version=1.11.20045.2, Culture=neutral, PublicKeyToken=23ec7fc2d6eaa4a5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.SqlClient.1.1.1\lib\net46\Microsoft.Data.SqlClient.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.DotNet.InternalAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.DotNet.InternalAbstractions.1.0.0\lib\net451\Microsoft.DotNet.InternalAbstractions.dll</HintPath>
       <Private>True</Private>
@@ -149,24 +146,6 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Primitives.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client, Version=3.0.8.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.3.0.8\lib\net45\Microsoft.Identity.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.5.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.5.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.5.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.5.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.5.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
@@ -175,9 +154,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\NHibernate.5.2.5\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
@@ -192,11 +168,9 @@
     <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
-    <Reference Include="RepoDb, Version=1.10.11.4, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RepoDb.1.10.11\lib\netstandard2.0\RepoDb.dll</HintPath>
-    </Reference>
-    <Reference Include="RepoDb.SqlServer, Version=1.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RepoDb.SqlServer.1.0.6\lib\netstandard2.0\RepoDb.SqlServer.dll</HintPath>
+    <Reference Include="RepoDb, Version=1.9.5.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\RepoDb.1.9.5\lib\net40\RepoDb.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SD.LLBLGen.Pro.DQE.SqlServer, Version=5.6.0.0, Culture=neutral, PublicKeyToken=ca73b74ba4e3ff27">
       <HintPath>..\packages\SD.LLBLGen.Pro.DQE.SqlServer.5.6.0-Beta-20190708\lib\net452\SD.LLBLGen.Pro.DQE.SqlServer.dll</HintPath>
@@ -246,23 +220,14 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Common, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.Common.4.3.0\lib\net451\System.Data.Common.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Data.SqlClient, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SqlClient.4.8.0\lib\net461\System.Data.SqlClient.dll</HintPath>
+    <Reference Include="System.Data.SqlClient, Version=4.5.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Data.SqlClient.4.6.1\lib\net461\System.Data.SqlClient.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.5.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async, Version=3.2.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263">
       <HintPath>..\packages\System.Interactive.Async.3.2.0\lib\net46\System.Interactive.Async.dll</HintPath>
@@ -285,9 +250,6 @@
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.TypeExtensions.4.4.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
@@ -330,7 +292,6 @@
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -479,9 +440,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.2.9.3\build\Microsoft.CodeAnalysis.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.2.9.3\build\Microsoft.CodeAnalysis.Analyzers.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets" Condition="Exists('..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RawBencher/RawBencher.csproj
+++ b/RawBencher/RawBencher.csproj
@@ -85,6 +85,9 @@
       <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.3.1.0\lib\netstandard2.0\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Data.SqlClient, Version=1.11.20045.2, Culture=neutral, PublicKeyToken=23ec7fc2d6eaa4a5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.SqlClient.1.1.1\lib\net46\Microsoft.Data.SqlClient.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.DotNet.InternalAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.DotNet.InternalAbstractions.1.0.0\lib\net451\Microsoft.DotNet.InternalAbstractions.dll</HintPath>
       <Private>True</Private>
@@ -146,6 +149,24 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Primitives.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Identity.Client, Version=3.0.8.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.3.0.8\lib\net45\Microsoft.Identity.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.5.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.5.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.5.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.5.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.5.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
@@ -154,6 +175,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
       <HintPath>..\packages\NHibernate.5.2.5\lib\net461\NHibernate.dll</HintPath>
       <Private>True</Private>
@@ -168,9 +192,11 @@
     <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
       <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
-    <Reference Include="RepoDb, Version=1.9.5.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\RepoDb.1.9.5\lib\net40\RepoDb.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RepoDb, Version=1.10.11.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RepoDb.1.10.11\lib\netstandard2.0\RepoDb.dll</HintPath>
+    </Reference>
+    <Reference Include="RepoDb.SqlServer, Version=1.0.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RepoDb.SqlServer.1.0.6\lib\netstandard2.0\RepoDb.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="SD.LLBLGen.Pro.DQE.SqlServer, Version=5.6.0.0, Culture=neutral, PublicKeyToken=ca73b74ba4e3ff27">
       <HintPath>..\packages\SD.LLBLGen.Pro.DQE.SqlServer.5.6.0-Beta-20190708\lib\net452\SD.LLBLGen.Pro.DQE.SqlServer.dll</HintPath>
@@ -220,14 +246,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Data.SqlClient, Version=4.5.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Data.SqlClient.4.6.1\lib\net461\System.Data.SqlClient.dll</HintPath>
+    <Reference Include="System.Data.Common, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.Common.4.3.0\lib\net451\System.Data.Common.dll</HintPath>
       <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Data.SqlClient, Version=4.6.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SqlClient.4.8.0\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.5.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async, Version=3.2.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263">
       <HintPath>..\packages\System.Interactive.Async.3.2.0\lib\net46\System.Interactive.Async.dll</HintPath>
@@ -250,6 +285,9 @@
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.TypeExtensions.4.4.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
@@ -292,6 +330,7 @@
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -440,7 +479,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.2.9.3\build\Microsoft.CodeAnalysis.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.2.9.3\build\Microsoft.CodeAnalysis.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets" Condition="Exists('..\packages\Microsoft.Data.SqlClient.SNI.1.1.0\build\net46\Microsoft.Data.SqlClient.SNI.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RawBencher/packages.config
+++ b/RawBencher/packages.config
@@ -13,8 +13,6 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="3.1.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Scripting.Common" version="3.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
-  <package id="Microsoft.Data.SqlClient" version="1.1.1" targetFramework="net472" />
-  <package id="Microsoft.Data.SqlClient.SNI" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net462" />
   <package id="Microsoft.EntityFrameworkCore" version="2.2.6" targetFramework="net472" />
@@ -34,23 +32,15 @@
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.OptionsModel" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net462" />
-  <package id="Microsoft.Identity.Client" version="3.0.8" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.5.0" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Logging" version="5.5.0" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Protocols" version="5.5.0" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.5.0" targetFramework="net472" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.5.0" targetFramework="net472" />
   <package id="Microsoft.NETCore.Platforms" version="2.2.2" targetFramework="net472" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net472" />
   <package id="NHibernate" version="5.2.5" targetFramework="net472" />
   <package id="NPoco" version="4.0.1" targetFramework="net472" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net462" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net462" />
-  <package id="RepoDb" version="1.10.11" targetFramework="net472" />
-  <package id="RepoDb.SqlServer" version="1.0.6" targetFramework="net472" />
+  <package id="RepoDb" version="1.9.5" targetFramework="net472" />
   <package id="SD.LLBLGen.Pro.DQE.SqlServer" version="5.6.0-Beta-20190708" targetFramework="net472" />
   <package id="SD.LLBLGen.Pro.ORMSupportClasses" version="5.6.0-Beta-20190708" targetFramework="net472" />
   <package id="ServiceStack.Common" version="5.5.0" targetFramework="net472" />
@@ -68,8 +58,7 @@
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Console" version="4.3.1" targetFramework="net462" />
-  <package id="System.Data.Common" version="4.3.0" targetFramework="net472" />
-  <package id="System.Data.SqlClient" version="4.8.0" targetFramework="net472" />
+  <package id="System.Data.SqlClient" version="4.6.1" targetFramework="net472" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net461" />
@@ -79,7 +68,6 @@
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.5.0" targetFramework="net472" />
   <package id="System.Interactive.Async" version="3.2.0" targetFramework="net462" />
   <package id="System.IO" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
@@ -96,12 +84,9 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
-  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
-  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Reflection.TypeExtensions" version="4.4.0" targetFramework="net472" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net462" />

--- a/RawBencher/packages.config
+++ b/RawBencher/packages.config
@@ -13,6 +13,8 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="3.1.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Scripting.Common" version="3.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net462" />
+  <package id="Microsoft.Data.SqlClient" version="1.1.1" targetFramework="net472" />
+  <package id="Microsoft.Data.SqlClient.SNI" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net462" />
   <package id="Microsoft.EntityFrameworkCore" version="2.2.6" targetFramework="net472" />
@@ -32,15 +34,23 @@
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.OptionsModel" version="1.0.0-rc1-final" targetFramework="net451" />
   <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net462" />
+  <package id="Microsoft.Identity.Client" version="3.0.8" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.5.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.5.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.5.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.5.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.5.0" targetFramework="net472" />
   <package id="Microsoft.NETCore.Platforms" version="2.2.2" targetFramework="net472" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net472" />
   <package id="NHibernate" version="5.2.5" targetFramework="net472" />
   <package id="NPoco" version="4.0.1" targetFramework="net472" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net462" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net462" />
-  <package id="RepoDb" version="1.9.5" targetFramework="net472" />
+  <package id="RepoDb" version="1.10.11" targetFramework="net472" />
+  <package id="RepoDb.SqlServer" version="1.0.6" targetFramework="net472" />
   <package id="SD.LLBLGen.Pro.DQE.SqlServer" version="5.6.0-Beta-20190708" targetFramework="net472" />
   <package id="SD.LLBLGen.Pro.ORMSupportClasses" version="5.6.0-Beta-20190708" targetFramework="net472" />
   <package id="ServiceStack.Common" version="5.5.0" targetFramework="net472" />
@@ -58,7 +68,8 @@
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.Console" version="4.3.1" targetFramework="net462" />
-  <package id="System.Data.SqlClient" version="4.6.1" targetFramework="net472" />
+  <package id="System.Data.Common" version="4.3.0" targetFramework="net472" />
+  <package id="System.Data.SqlClient" version="4.8.0" targetFramework="net472" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net461" />
@@ -68,6 +79,7 @@
   <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.5.0" targetFramework="net472" />
   <package id="System.Interactive.Async" version="3.2.0" targetFramework="net462" />
   <package id="System.IO" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
@@ -84,9 +96,12 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net462" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.TypeExtensions" version="4.4.0" targetFramework="net472" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net462" />


### PR DESCRIPTION
Hi Franz,

I made some changes on the bencher. In the `BenchController`, I had added a new method named `Bootstrap()` and it is being called within the `Run()` method. The intention of this method is to contain all the necessary bootstrapping for the registered ORM(s) (not just RepoDb).

> I have to do this as I already had separated the SQL Server into its own dedicated package named `RepoDb.SqlServer`. I need to call the `RepoDb.SqlServerBootstrap.Initialize()` method in order for it to work. For the sake of code organization on this bencher, I had added this method.

Also, you will notice that the `System.Data.SqlClient` version has been upgraded from `4.6.1` to `4.8.0`. This upgrade does not create any conflicts, or please do let me know if this concerns you.

Otherwise, please accept these changes with the latest and greatest version of RepoDb in place.

Thanks and cheers!