### PR TITLE
Update Linq2DB to 3.0.1

### DIFF
--- a/LINQ2DB/DAL/LINQ2DB.Bencher.csproj
+++ b/LINQ2DB/DAL/LINQ2DB.Bencher.csproj
@@ -31,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="linq2db, Version=2.9.7.0, Culture=neutral, PublicKeyToken=e41013125f9e410a">
-      <HintPath>..\..\packages\linq2db.2.9.7\lib\net46\linq2db.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="linq2db, Version=3.0.1.0, Culture=neutral, PublicKeyToken=e41013125f9e410a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\linq2db.3.0.1\lib\net46\linq2db.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/LINQ2DB/DAL/packages.config
+++ b/LINQ2DB/DAL/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="linq2db" version="2.9.7" targetFramework="net462" />
+  <package id="linq2db" version="3.0.1" targetFramework="net462" />
 </packages>

--- a/RawBencher.Core/RawBencher.Core.csproj
+++ b/RawBencher.Core/RawBencher.Core.csproj
@@ -58,7 +58,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.35" />
-      <PackageReference Include="linq2db" Version="2.9.7" />
+      <PackageReference Include="linq2db" Version="3.0.1" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
       <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
       <PackageReference Include="NPoco" Version="4.0.2" />

--- a/RawBencher/RawBencher.csproj
+++ b/RawBencher/RawBencher.csproj
@@ -70,9 +70,8 @@
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="linq2db, Version=2.9.7.0, Culture=neutral, PublicKeyToken=e41013125f9e410a">
-      <HintPath>..\packages\linq2db.2.9.7\lib\net46\linq2db.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="linq2db, Version=3.0.1.0, Culture=neutral, PublicKeyToken=e41013125f9e410a, processorArchitecture=MSIL">
+      <HintPath>..\packages\linq2db.3.0.1\lib\net46\linq2db.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/RawBencher/packages.config
+++ b/RawBencher/packages.config
@@ -7,7 +7,7 @@
   <package id="EntityFramework" version="6.4.0" targetFramework="net472" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net462" />
   <package id="Ix-Async" version="1.2.5" targetFramework="net46" />
-  <package id="linq2db" version="2.9.7" targetFramework="net472" />
+  <package id="linq2db" version="3.0.1" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="3.0.0" targetFramework="net48" developmentDependency="true" />


### PR DESCRIPTION
Significant performance and memory use improvements in v3.0 vs v2.9